### PR TITLE
Dominion (#94)

### DIFF
--- a/examples/ONEAudit-demo.ipynb
+++ b/examples/ONEAudit-demo.ipynb
@@ -90,6 +90,7 @@
     "+ Read manual interpretations of the cards (MVRs)\n",
     "+ Calculate attained risk for each assorter\n",
     "    - Use ~2EZ to deal with phantom CVRs or cards; the treatment depends on whether `use_style == True`\n",
+    "    - If a sampled card cannot be found/retrieved, use the phantom-to-zombie transformation for it\n",
     "    - Use the pooled assorter means for cards in pooled batches\n",
     "+ Report\n",
     "+ Estimate incremental sample size if any assorter nulls have not been rejected\n",
@@ -1006,7 +1007,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Read the audited sample data"
+    "# Read the audited sample data.\n",
+    "\n",
+    "## Any ballot that cannot be retrieved should be marked as a \"zombie\" (treated in the least favorable way for every contest it might contain)."
    ]
   },
   {

--- a/shangrla/core/Audit.py
+++ b/shangrla/core/Audit.py
@@ -1931,7 +1931,8 @@ class Assertion:
     @classmethod
     def make_supermajority_assertion(
         cls,
-        contest,
+        contest: object=None,
+        share_to_win: float = 1/2,
         winner: str = None,
         loser: list = None,
         share_to_win: float = None,
@@ -1963,12 +1964,12 @@ class Assertion:
         -----------
         contest:
             contest object instance to which the assertion applies
+        share_to_win: float
+            fraction of the valid votes the winner must get to win
         winner:
             identifier of winning candidate
         loser: list
             list of identifiers of losing candidate(s)
-        share_to_win: float
-            fraction of the valid votes the winner must get to win
         test: instance of NonnegMean
             risk function for the contest
         estim: an estimation method of NonnegMean

--- a/tests/formats/test_Dominion.py
+++ b/tests/formats/test_Dominion.py
@@ -56,12 +56,12 @@ class TestDominion:
         assert not cvr_1.pool, f"{cvr_1.pool=}"
         assert list(cvr_1.votes.keys()) == ["111"]
         # Reading Dominion CVRs now takes "IsVote" and "Modified" values into account,
-        # so {"6": 1, "1": 2} now becomes {"6": 1, "1": 0} (vote for candidate 1 in this
+        # so {"6": 1, "1": 2} now becomes {"6": 1} (vote for candidate 1 in this
         # testcase is marked "IsVote": false).  For the same reason, the call to
-        # get_vote_for("111", "1") is now 0.
-        assert cvr_1.votes["111"] == {"6": 1, "1": 0}
+        # get_vote_for("111", "1") is now False.
+        assert cvr_1.votes["111"] == {"6": 1}
         assert cvr_1.get_vote_for("111", "6")
-        assert cvr_1.get_vote_for("111", "1") == 0
+        assert cvr_1.get_vote_for("111", "1") is False
         assert cvr_1.get_vote_for("111", "999") is False
         assert cvr_2.id == "60009_3_21"
         assert cvr_2.tally_pool == "60009_3"


### PR DESCRIPTION
* BUG: change logic for parsing Dominion ranks, fix minor bugs in supermajority

* BUG: revise unit test for Dominion to match new mark processing

* ENH: logic for SF treatment of multiple ranks assigned to same candidate in IRV

* ENH: logic for SF treatment of multiple ranks assigned to same candidate in IRV

* ENH: logic for SF treatment of multiple ranks assigned to same candidate in IRV

* ENH: logic for SF treatment of multiple ranks assigned to same candidate in IRV